### PR TITLE
Don't use shaped arrays

### DIFF
--- a/xover-fixed.p6
+++ b/xover-fixed.p6
@@ -8,8 +8,8 @@ while $len <= $maxlen {
     for 1..$how-many  {
 	my $start = ($len -2 ).rand.Int;
 	my $this-len = 1+($len-$start-2).rand.Int;
-	my @chromosome1[$len] = Bool.roll xx $len;
-	my @chromosome2[$len] = Bool.roll xx $len;
+	my @chromosome1 = Bool.roll xx $len;
+	my @chromosome2 = Bool.roll xx $len;
 	my @out1 = Array.new( @chromosome2.head($start)).append(@chromosome1.skip($start).head($this-len)).append( @chromosome2.tail($len-$this-len-$start));
 	my @out2 = Array.new( @chromosome1.head($start)).append(@chromosome2.skip($start).head($this-len)).append( @chromosome1.tail($len-$this-len-$start));
     }


### PR DESCRIPTION
They currently are slower than regular arrays. On my system, the times for lengths 16 and 32 (I didn't collect times for the longer lengths) dropped by about 5s and 7s.